### PR TITLE
 [서버 사이드 렌더링 - 1단계] 소파(차승하) 미션 제출합니다.

### DIFF
--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,11 +1,30 @@
-import React from "react";
-import Home from "./components/Home";
+import Home from './components/Home';
+import React from 'react';
+import colorsCss from '../../public/styles/colors.css';
+import mainCss from '../../public/styles/main.css';
+import modalCss from '../../public/styles/modal.css';
+import resetCss from '../../public/styles/reset.css';
+import tabCss from '../../public/styles/tab.css';
+import thumbnailCss from '../../public/styles/thumbnail.css';
 
-function App() {
+function App({ movies }) {
   return (
-    <div>
-      <Home />
-    </div>
+    <html lang='ko'>
+      <head>
+        <meta charSet='UTF-8' />
+        <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+        <link rel='stylesheet' href={colorsCss} />
+        <link rel='stylesheet' href={mainCss} />
+        <link rel='stylesheet' href={modalCss} />
+        <link rel='stylesheet' href={resetCss} />
+        <link rel='stylesheet' href={tabCss} />
+        <link rel='stylesheet' href={thumbnailCss} />
+        <title>영화 리뷰</title>
+      </head>
+      <body>
+        <Home movies={movies} />
+      </body>
+    </html>
   );
 }
 

--- a/src/client/apis/fetchJsonData.js
+++ b/src/client/apis/fetchJsonData.js
@@ -1,0 +1,9 @@
+import { FETCH_OPTIONS } from '../constants.js';
+
+const fetchJsonData = async url => {
+  const response = await fetch(url, FETCH_OPTIONS);
+  const data = await response.json();
+  return data;
+};
+
+export default fetchJsonData;

--- a/src/client/apis/getMovieDetail.js
+++ b/src/client/apis/getMovieDetail.js
@@ -1,0 +1,46 @@
+import { FETCH_OPTIONS, TMDB_MOVIE_DETAIL_URL } from '../constants.js';
+
+/**
+ * @typedef {Object} MovieDetail
+ * @property {boolean} adult - 성인 영화 여부
+ * @property {string} backdrop_path - 배경 이미지 경로
+ * @property {?Object} belongs_to_collection - 컬렉션 정보 (없을 경우 null)
+ * @property {number} budget - 예산
+ * @property {Genre[]} genres - 장르 목록
+ * @property {string} homepage - 홈페이지 URL
+ * @property {number} id - 영화 ID
+ * @property {string} imdb_id - IMDb ID
+ * @property {string[]} origin_country - 제작 국가
+ * @property {string} original_language - 원어
+ * @property {string} original_title - 원제
+ * @property {string} overview - 영화 개요
+ * @property {number} popularity - 인기 지수
+ * @property {string} poster_path - 포스터 이미지 경로
+ * @property {ProductionCompany[]} production_companies - 제작사 목록
+ * @property {ProductionCountry[]} production_countries - 제작 국가 정보
+ * @property {string} release_date - 개봉일
+ * @property {number} revenue - 수익
+ * @property {number} runtime - 상영 시간 (분)
+ * @property {Language[]} spoken_languages - 사용 언어 목록
+ * @property {string} status - 영화 상태
+ * @property {string} tagline - 태그라인
+ * @property {string} title - 영화 제목
+ * @property {boolean} video - 비디오 여부
+ * @property {number} vote_average - 평균 평점
+ * @property {number} vote_count - 투표 수
+ */
+
+/**
+ *
+ * @param {number} id
+ * @returns {Promise<MovieDetail>}
+ */
+export default async function getMovieDetail(id) {
+  const url = TMDB_MOVIE_DETAIL_URL + id;
+  const params = new URLSearchParams({
+    language: 'ko-KR',
+  });
+  const response = await fetch(url + '?' + params, FETCH_OPTIONS);
+
+  return await response.json();
+}

--- a/src/client/apis/getMovies.js
+++ b/src/client/apis/getMovies.js
@@ -1,0 +1,72 @@
+import { TMDB_MOVIE_LISTS } from '../constants.js';
+import fetchJsonData from './fetchJsonData.js';
+
+/**
+ * @typedef {Object} Movie
+ * @property {boolean} adult - 성인 여부
+ * @property {string} backdrop_path - 배경 이미지 경로
+ * @property {number[]} genre_ids - 장르 ID 배열
+ * @property {number} id - 영화 ID
+ * @property {string} original_language - 원래 언어
+ * @property {string} original_title - 원제
+ * @property {string} overview - 영화 개요
+ * @property {number} popularity - 인기 지수
+ * @property {string} poster_path - 포스터 이미지 경로
+ * @property {string} release_date - 개봉일
+ * @property {string} title - 제목
+ * @property {boolean} video - 비디오 여부
+ * @property {number} vote_average - 평균 평점
+ * @property {number} vote_count - 평점 수
+ */
+
+/**
+ * @returns {Promise<Movie[]>} 영화 응답 데이터
+ */
+const getPopularMovies = async () => {
+  const response = await fetchJsonData(TMDB_MOVIE_LISTS.popular);
+  return response.results;
+};
+
+/**
+ * @returns {Promise<Movie[]>} 영화 응답 데이터
+ */
+const getNowPlayingMovies = async () => {
+  const response = await fetchJsonData(TMDB_MOVIE_LISTS.nowPlaying);
+  return response.results;
+};
+
+/**
+ * @returns {Promise<Movie[]>} 영화 응답 데이터
+ */
+const getTopRatedMovies = async () => {
+  const response = await fetchJsonData(TMDB_MOVIE_LISTS.topRated);
+  return response.results;
+};
+
+/**
+ * @returns {Promise<Movie[]>} 영화 응답 데이터
+ */
+const getUpcomingMovies = async () => {
+  const response = await fetchJsonData(TMDB_MOVIE_LISTS.upcoming);
+  return response.results;
+};
+
+/**
+ * @typedef {Object} getMovies
+ * @property {function(): Promise<Movie[]>} popular - 인기 영화 가져오기 함수
+ * @property {function(): Promise<Movie[]>} nowPlaying - 현재 상영 중인 영화 가져오기 함수
+ * @property {function(): Promise<Movie[]>} topRated - 평점 높은 영화 가져오기 함수
+ * @property {function(): Promise<Movie[]>} upcoming - 개봉 예정 영화 가져오기 함수
+ */
+
+/**
+ * @type {getMovies}
+ */
+const getMovies = {
+  popular: getPopularMovies,
+  nowPlaying: getNowPlayingMovies,
+  topRated: getTopRatedMovies,
+  upcoming: getUpcomingMovies,
+};
+
+export default getMovies;

--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -1,7 +1,90 @@
-import React from "react";
+import MovieThumbnail from './MovieThumbnail.jsx';
+import React from 'react';
+import { TMDB_THUMBNAIL_URL } from '../constants.js';
+import logoPng from '../../../public/images/logo.png';
+import starEmptyPng from '../../../public/images/star_empty.png';
+import woowacourseLogo from '../../../public/images/woowacourse_logo.png';
 
-function Home() {
-  return <div>Home</div>;
+function Home({ movies }) {
+  const bestMovie = movies[0] || {};
+  return (
+    <div id='wrap'>
+      <header>
+        <div
+          className='background-container'
+          style={{
+            backgroundImage: `url(${TMDB_THUMBNAIL_URL}${bestMovie.poster_path})`,
+          }}
+        >
+          <div className='overlay' aria-hidden='true'></div>
+          <div className='top-rated-container'>
+            <h1 className='logo'>
+              <img src={logoPng} alt='MovieList' />
+            </h1>
+            <div className='top-rated-movie'>
+              <div className='rate'>
+                <img src={starEmptyPng} className='star' />
+                <span className='rate-value'>
+                  {bestMovie.vote_average.toFixed(1)}
+                </span>
+              </div>
+              <div className='title'>{bestMovie.title}</div>
+              <button className='primary detail'>자세히 보기</button>
+            </div>
+          </div>
+        </div>
+      </header>
+      <div className='container'>
+        {/* <ul className='tab'>
+          <li>
+            <a href='/now-playing'>
+              <div className='tab-item'>
+                <h3>상영 중</h3>
+              </div>
+            </a>
+          </li>
+          <li>
+            <a href='/popular'>
+              <div className='tab-item'>
+                <h3>인기순</h3>
+              </div>
+            </a>
+          </li>
+          <li>
+            <a href='/top-rated'>
+              <div className='tab-item'>
+                <h3>평점순</h3>
+              </div>
+            </a>
+          </li>
+          <li>
+            <a href='/upcoming'>
+              <div className='tab-item'>
+                <h3>상영 예정</h3>
+              </div>
+            </a>
+          </li>
+        </ul> */}
+        <main>
+          <section>
+            <h2>지금 인기 있는 영화</h2>
+            <ul className='thumbnail-list'>
+              {movies.map(movie => {
+                return <MovieThumbnail key={movie.id} movie={movie} />;
+              })}
+            </ul>
+          </section>
+        </main>
+      </div>
+
+      <footer className='footer'>
+        <p>&copy; 우아한테크코스 All Rights Reserved.</p>
+        <p>
+          <img src={woowacourseLogo} width='180' />
+        </p>
+      </footer>
+    </div>
+  );
 }
 
 export default Home;

--- a/src/client/components/MovieThumbnail.jsx
+++ b/src/client/components/MovieThumbnail.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { TMDB_THUMBNAIL_URL } from '../constants';
+import startEmptyPng from '../../../public/images/star_empty.png';
+
+export default function MovieThumbnail({ movie }) {
+  return (
+    <li>
+      <div className='item'>
+        <img
+          className='thumbnail'
+          src={`${TMDB_THUMBNAIL_URL}${movie.poster_path}`}
+          alt={movie.title}
+        />
+        <div className='item-desc'>
+          <p className='rate'>
+            <img src={startEmptyPng} className='star' />
+            <span>{movie.vote_average.toFixed(1)}</span>
+          </p>
+          <strong>{movie.title}</strong>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/client/constants.js
+++ b/src/client/constants.js
@@ -1,0 +1,29 @@
+export const BASE_URL = 'https://api.themoviedb.org/3/movie';
+
+export const TMDB_THUMBNAIL_URL =
+  'https://media.themoviedb.org/t/p/w440_and_h660_face/';
+export const TMDB_ORIGINAL_URL = 'https://image.tmdb.org/t/p/original/';
+export const TMDB_BANNER_URL =
+  'https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/';
+export const TMDB_MOVIE_LISTS = {
+  popular: BASE_URL + '/popular?language=ko-KR&page=1',
+  nowPlaying: BASE_URL + '/now_playing?language=ko-KR&page=1',
+  topRated: BASE_URL + '/top_rated?language=ko-KR&page=1',
+  upcoming: BASE_URL + '/upcoming?language=ko-KR&page=1',
+};
+export const TMDB_MOVIE_DETAIL_URL = 'https://api.themoviedb.org/3/movie/';
+
+export const FETCH_OPTIONS = {
+  method: 'GET',
+  headers: {
+    accept: 'application/json',
+    Authorization: 'Bearer ' + process.env.TMDB_TOKEN,
+  },
+};
+
+export const MOVIE_TYPE_TAP_ITEM_KO = {
+  nowPlaying: '상영 중',
+  popular: '인기순',
+  topRated: '평점순',
+  upcoming: '상영 예정',
+};

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -1,9 +1,9 @@
-import "./config.js";
-import express from "express";
-import path from "path";
-import { fileURLToPath } from "url";
+import './config.js';
 
-import movieRouter from "./routes/index.js";
+import express from 'express';
+import { fileURLToPath } from 'url';
+import movieRouter from './routes/index.js';
+import path from 'path';
 
 const app = express();
 const PORT = 3000;
@@ -11,9 +11,12 @@ const PORT = 3000;
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-app.use("/assets", express.static(path.join(__dirname, "../../public")));
+app.use(
+  '/assets',
+  express.static(path.join(__dirname, '../../dist/server/assets'))
+);
 
-app.use("/", movieRouter);
+app.use('/', movieRouter);
 
 // Start server
 app.listen(PORT, () => {

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,22 +1,12 @@
-import { Router } from "express";
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
-
-import React from "react";
-import { renderToString } from "react-dom/server";
-import App from "../../client/App";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import App from '../../client/App';
+import React from 'react';
+import { Router } from 'express';
+import getMovies from '../../client/apis/getMovies';
+import { renderToString } from 'react-dom/server';
 
 const router = Router();
 
-router.get("/", (_, res) => {
-  const templatePath = path.join(__dirname, "../../../views", "index.html");
-  const renderedApp = renderToString(<App />);
-
-  const template = fs.readFileSync(templatePath, "utf-8");
+router.use('*', async (_, res) => {
   // const initData = template.replace(
   //   "<!--${INIT_DATA_AREA}-->",
   //   /*html*/ `
@@ -27,9 +17,11 @@ router.get("/", (_, res) => {
   //   </script>
   // `
   // );
-  const renderedHTML = template.replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", renderedApp);
 
-  res.send(renderedHTML);
+  const movies = await getMovies.nowPlaying();
+  const renderedApp = renderToString(<App movies={movies} />);
+
+  res.send(renderedApp);
 });
 
 export default router;

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -1,15 +1,14 @@
-const path = require("path");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-const CopyPlugin = require("copy-webpack-plugin");
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 
 module.exports = {
-  module: "development",
-  entry: "./src/client/main.js",
+  module: 'development',
+  entry: './src/client/main.js',
   output: {
-    path: path.resolve("dist/client"),
-    filename: "bundle.js",
+    path: path.resolve('dist/client'),
+    filename: 'bundle.js',
     clean: true,
-    publicPath: "/",
   },
   module: {
     rules: [
@@ -17,29 +16,39 @@ module.exports = {
         test: /\.(jsx?)$/,
         exclude: /node_modules/,
         use: {
-          loader: "babel-loader",
+          loader: 'babel-loader',
           options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"],
+            presets: ['@babel/preset-env', '@babel/preset-react'],
           },
         },
       },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        type: 'asset/resource',
+        generator: {
+          filename: 'assets/[hash][ext]',
+        },
+      },
+      {
+        test: /\.(png|jpg|jpeg|gif|svg)$/i,
+        type: 'asset/resource',
+        generator: {
+          filename: 'assets/[hash][ext]',
+        },
       },
     ],
   },
   plugins: [
     new HtmlWebpackPlugin({
-      template: "./views/index.html",
+      template: './views/index.html',
     }),
     new CopyPlugin({
       patterns: [
-        { from: "public/images", to: "images" }, // public 폴더의 이미지를 dist로 복사
+        { from: 'public/images', to: 'images' }, // public 폴더의 이미지를 dist로 복사
       ],
     }),
   ],
   resolve: {
-    extensions: [".js", ".jsx"],
+    extensions: ['.js', '.jsx'],
   },
 };

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -1,11 +1,12 @@
-const path = require("path");
+const path = require('path');
 
 module.exports = {
-  mode: "development",
-  target: "node",
-  entry: path.resolve(__dirname, "src/server/main.js"),
+  mode: 'development',
+  target: 'node',
+  entry: path.resolve(__dirname, 'src/server/main.js'),
+
   resolve: {
-    extensions: [".js", ".jsx"],
+    extensions: ['.js', '.jsx'],
   },
   module: {
     rules: [
@@ -13,20 +14,31 @@ module.exports = {
         test: /\.(jsx?)$/,
         exclude: /node_modules/,
         use: {
-          loader: "babel-loader",
+          loader: 'babel-loader',
           options: {
-            presets: ["@babel/preset-env", "@babel/preset-react"],
+            presets: ['@babel/preset-env', '@babel/preset-react'],
           },
         },
       },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        type: 'asset/resource',
+        generator: {
+          filename: 'assets/[hash][ext]',
+        },
+      },
+      {
+        test: /\.(png|jpg|jpeg|gif|svg)$/i,
+        type: 'asset/resource',
+        generator: {
+          filename: 'assets/[hash][ext]',
+        },
       },
     ],
   },
   output: {
-    filename: "server.js",
-    path: path.resolve(__dirname, "dist/server"),
+    filename: 'server.js',
+    path: path.resolve(__dirname, 'dist/server'),
+    publicPath: '/',
   },
 };


### PR DESCRIPTION
안녕하세요 라이언~ 또 만났네여 히읗히읗

저는 이번 미션을 좀 특이하게 App에서 html 전체를 다 그리는 방식으로 진행했어요.

SSR을 파다보니 이런 함수를 공부하게 되었는데(https://ko.react.dev/reference/react-dom/server/renderToPipeableStream)

보니까 html 전체를 보내는 것이 유리하다고 해서 일단 App 전체를 html로 만들었습니다.

이 함수의 특징은 다음과 같아요. 데이터 패칭이 필요한 부분은 서스펜스로 감싸서 html로 보내고 추후에 서버에서 데이터 패칭이 이뤄져 그 부분의 html이 만들어 진다면 그 부분을 html로 바꾸어서 다시 클라이언트로 보내주는 것입니다.

이런 것을 대비해 이렇게 만들긴 했는데요. 만들고 보니
`서버단에서 데이터 패칭을 하는 컴포넌트가 없는데 너무 앞서나간 것이 아닌가?`하는 생각이 들었어요. 또 미션에서 제시하는 방향과 너무 어긋나는 방향으로 미션을 진행한게 아닌가 하는 생각도 들었고요

그래서 원상복구를 하려고 했으나 시간관계상 이렇게 제출을 합니다. 

SSR 렌더링 시 초기 렌더링 성능이 왜 유리할까?
![CSR](https://github.com/user-attachments/assets/d39d6496-f8c4-4a6a-85a9-16bada5678e0)
<img width="2148" alt="SSR" src="https://github.com/user-attachments/assets/bcd07795-8aab-4bd4-876b-61b2d36eaef1">

도식화해서 이해를 하는 시간을 가져봤습니다.

특정 origin으로 보내는 요청은 같은 시간이 걸린다고 가정하고 생각을 해볼 수 있었습니다.(ex:tmdb로 부터 응답을 받는 시간은 클라이언트 서버나 클라이언트 컴퓨터나 같다고 생각하겠습니다)

두 방식에서 렌더링에 영향을 미치는 차이는 두 가지였습니다.
1) CSR은 SSR에 비해 JS를 받아오는 시간이 추가로 걸린다
2) CSR은 브라우저 렌더링이 한 번 다 이뤄지고 나서 DOM 업데이트 이후 tmdb로의 요청을 보내고, 이후 tmdb로부터 데이터를 읽어와 다시 한 번 더 DOM 업데이트가 일어난다.

이 중 2번 때문에 렌더링 성능에 치명적인 영향을 미친다는 생각이 들었습니다.


2. 서버에서 렌더링한 영화 목록을 어떻게 클라이언트에 데이터를 전달하고 브라우저에서는 어떤 작업을 수행할까?
도식화한 사진에서도 잘 나와있듯이, CSR에서는 프론트엔드 서버는 영화목록을 제공하지 않고, SSR에서는 tmdb 서버에서 데이터를 받아와 클라이언트로 데이터를 직접 보내줍니다.



3. 전역 객체 초기화 작업은 왜 진행해야 할까?
서버의 전역 객체를 기준으로 그려진 React 컴포넌트가 클라이언트에서도 동일하게 그려져야하기 때문이라고 생각합니다.

사실 저는 미션에서 제시한 에러가 나지 않았는데요 라이언은 어떨 때 에러가 났는지 궁금합니다
