### PR TITLE
[서버 사이드 렌더링 - 1단계] 수야(최영수) 미션 제출합니다.

### DIFF
--- a/src/api/tmdb.js
+++ b/src/api/tmdb.js
@@ -1,0 +1,25 @@
+const BASE_URL = "https://api.themoviedb.org/3/movie";
+
+const FETCH_OPTIONS = {
+  method: "GET",
+  headers: {
+    accept: "application/json",
+    Authorization: "Bearer " + process.env.TMDB_TOKEN,
+  },
+};
+
+export const TMDB_MOVIE_LISTS = {
+  nowPlaying: BASE_URL + "/now_playing?language=ko-KR&page=1",
+};
+const TMDB_BANNER_URL =
+  "https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/";
+
+export const getMovies = async (url) => {
+  const response = await fetch(url, FETCH_OPTIONS);
+  const data = await response.json();
+  return data.results;
+};
+
+export const getBackgroundImageUrl = (movie) => {
+  return TMDB_BANNER_URL + movie.backdrop_path;
+};

--- a/src/api/tmdb.js
+++ b/src/api/tmdb.js
@@ -13,6 +13,8 @@ export const TMDB_MOVIE_LISTS = {
 };
 const TMDB_BANNER_URL =
   "https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/";
+const TMDB_THUMBNAIL_URL =
+  "https://media.themoviedb.org/t/p/w440_and_h660_face/";
 
 export const getMovies = async (url) => {
   const response = await fetch(url, FETCH_OPTIONS);
@@ -22,4 +24,8 @@ export const getMovies = async (url) => {
 
 export const getBackgroundImageUrl = (movie) => {
   return TMDB_BANNER_URL + movie.backdrop_path;
+};
+
+export const getThumbnailUrl = (movie) => {
+  return TMDB_THUMBNAIL_URL + movie.poster_path;
 };

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,12 +1,8 @@
 import React from "react";
-import Home from "./components/Home";
+import MovieList from "./components/MovieList";
 
-function App() {
-  return (
-    <div>
-      <Home />
-    </div>
-  );
+function App({ movies }) {
+  return <MovieList movies={movies} />;
 }
 
 export default App;

--- a/src/client/components/Home.jsx
+++ b/src/client/components/Home.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-
-function Home() {
-  return <div>Home</div>;
-}
-
-export default Home;

--- a/src/client/components/MovieList.jsx
+++ b/src/client/components/MovieList.jsx
@@ -1,6 +1,12 @@
 import React from "react";
-import { getThumbnailUrl } from "../../api/tmdb";
 import round from "../../utils/round";
+
+const TMDB_THUMBNAIL_URL =
+  "https://media.themoviedb.org/t/p/w440_and_h660_face/";
+
+const getThumbnailUrl = (movie) => {
+  return TMDB_THUMBNAIL_URL + movie.poster_path;
+};
 
 export default function MovieList({ movies }) {
   return (

--- a/src/client/components/MovieList.jsx
+++ b/src/client/components/MovieList.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { getThumbnailUrl } from "../../api/tmdb";
+import round from "../../utils/round";
+
+export default function MovieList({ movies }) {
+  return (
+    <React.Fragment>
+      {movies.map(({ id, title, vote_average, poster_path }) => (
+        <li key={id}>
+          <a>
+            <div className="item">
+              <img
+                className="thumbnail"
+                src={getThumbnailUrl({ poster_path })}
+                alt={title}
+              />
+              <div className="item-desc">
+                <p className="rate">
+                  <img
+                    src="../../assets/images/star_empty.png"
+                    className="star"
+                  />
+                  <span>{round(vote_average, 1)}</span>
+                </p>
+                <strong>{title}</strong>
+              </div>
+            </div>
+          </a>
+        </li>
+      ))}
+    </React.Fragment>
+  );
+}

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -2,4 +2,6 @@ import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import App from "./App";
 
-hydrateRoot(document.getElementById("movie-list"), <App />);
+const { movies } = window.__INITIAL_DATA__;
+
+hydrateRoot(document.getElementById("movie-list"), <App movies={movies} />);

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -2,4 +2,4 @@ import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import App from "./App";
 
-hydrateRoot(document.getElementById("root"), <App />);
+hydrateRoot(document.getElementById("movie-list"), <App />);

--- a/src/server/api/tmdb.js
+++ b/src/server/api/tmdb.js
@@ -13,8 +13,6 @@ export const TMDB_MOVIE_LISTS = {
 };
 const TMDB_BANNER_URL =
   "https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/";
-const TMDB_THUMBNAIL_URL =
-  "https://media.themoviedb.org/t/p/w440_and_h660_face/";
 
 export const getMovies = async (url) => {
   const response = await fetch(url, FETCH_OPTIONS);
@@ -24,8 +22,4 @@ export const getMovies = async (url) => {
 
 export const getBackgroundImageUrl = (movie) => {
   return TMDB_BANNER_URL + movie.backdrop_path;
-};
-
-export const getThumbnailUrl = (movie) => {
-  return TMDB_THUMBNAIL_URL + movie.poster_path;
 };

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -12,6 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 app.use("/assets", express.static(path.join(__dirname, "../../public")));
+app.use("/client", express.static(path.join(__dirname, "../../dist/client")));
 
 app.use("/", movieRouter);
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -6,17 +6,32 @@ import { fileURLToPath } from "url";
 import React from "react";
 import { renderToString } from "react-dom/server";
 import App from "../../client/App";
+import {
+  getMovies,
+  getBackgroundImageUrl,
+  TMDB_MOVIE_LISTS,
+} from "../../api/tmdb";
+import round from "../../utils/round";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const router = Router();
 
-router.get("/", (_, res) => {
+router.get("/", async (_, res) => {
   const templatePath = path.join(__dirname, "../../../views", "index.html");
+  const template = fs.readFileSync(templatePath, "utf-8");
+
+  const movies = await getMovies(TMDB_MOVIE_LISTS.nowPlaying);
+  const movie = movies[0] ?? {
+    id: -1,
+    title: "",
+    bannerUrl: "",
+    vote_average: 0,
+  };
+
   const renderedApp = renderToString(<App />);
 
-  const template = fs.readFileSync(templatePath, "utf-8");
   // const initData = template.replace(
   //   "<!--${INIT_DATA_AREA}-->",
   //   /*html*/ `
@@ -27,7 +42,12 @@ router.get("/", (_, res) => {
   //   </script>
   // `
   // );
-  const renderedHTML = template.replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", renderedApp);
+
+  const renderedHTML = template
+    .replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", renderedApp)
+    .replace("${background-container}", getBackgroundImageUrl(movie))
+    .replace("${bestMovie.rate}", round(movie.vote_average, 1))
+    .replace("${bestMovie.title}", movie.title);
 
   res.send(renderedHTML);
 });

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -19,7 +19,11 @@ const __dirname = path.dirname(__filename);
 const router = Router();
 
 router.get("/", async (_, res) => {
-  const templatePath = path.join(__dirname, "../../../views", "index.html");
+  const templatePath = path.join(
+    __dirname,
+    "../../../dist/client",
+    "index.html"
+  );
   const template = fs.readFileSync(templatePath, "utf-8");
 
   const movies = await getMovies(TMDB_MOVIE_LISTS.nowPlaying);

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -10,7 +10,7 @@ import {
   getMovies,
   getBackgroundImageUrl,
   TMDB_MOVIE_LISTS,
-} from "../../api/tmdb";
+} from "../api/tmdb";
 import round from "../../utils/round";
 
 const __filename = fileURLToPath(import.meta.url);

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -36,22 +36,21 @@ router.get("/", async (_, res) => {
 
   const renderedApp = renderToString(<App movies={movies} />);
 
-  // const initData = template.replace(
-  //   "<!--${INIT_DATA_AREA}-->",
-  //   /*html*/ `
-  //   <script>
-  //     window.__INITIAL_DATA__ = {
-  //       movies: ${JSON.stringify(popularMovies)}
-  //     }
-  //   </script>
-  // `
-  // );
-
   const renderedHTML = template
     .replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", renderedApp)
     .replace("${background-container}", getBackgroundImageUrl(movie))
     .replace("${bestMovie.rate}", round(movie.vote_average, 1))
-    .replace("${bestMovie.title}", movie.title);
+    .replace("${bestMovie.title}", movie.title)
+    .replace(
+      "<!--${INIT_DATA_AREA}-->",
+      /*html*/ `
+        <script>
+          window.__INITIAL_DATA__ = {
+            movies: ${JSON.stringify(movies)}
+          }
+        </script>
+      `
+    );
 
   res.send(renderedHTML);
 });

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -30,7 +30,7 @@ router.get("/", async (_, res) => {
     vote_average: 0,
   };
 
-  const renderedApp = renderToString(<App />);
+  const renderedApp = renderToString(<App movies={movies} />);
 
   // const initData = template.replace(
   //   "<!--${INIT_DATA_AREA}-->",

--- a/src/utils/round.js
+++ b/src/utils/round.js
@@ -1,0 +1,7 @@
+const round = (value, decimals = 0) => {
+  const factor = 10 ** decimals;
+
+  return Math.round(value * factor) / factor;
+};
+
+export default round;

--- a/views/index.html
+++ b/views/index.html
@@ -14,10 +14,15 @@
   <body>
     <div id="wrap">
       <header>
-        <div class="background-container" style="background-image: url('${background-container}')">
+        <div
+          class="background-container"
+          style="background-image: url('${background-container}')"
+        >
           <div class="overlay" aria-hidden="true"></div>
           <div class="top-rated-container">
-            <h1 class="logo"><img src="../assets/images/logo.png" alt="MovieList" /></h1>
+            <h1 class="logo">
+              <img src="../assets/images/logo.png" alt="MovieList" />
+            </h1>
             <div class="top-rated-movie">
               <div class="rate">
                 <img src="../assets/images/star_empty.png" class="star" />
@@ -33,7 +38,7 @@
         <main>
           <section>
             <h2>지금 인기 있는 영화</h2>
-            <ul class="thumbnail-list">
+            <ul id="movie-list" class="thumbnail-list">
               <!--${MOVIE_ITEMS_PLACEHOLDER}-->
             </ul>
           </section>

--- a/views/index.html
+++ b/views/index.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="../assets/styles/modal.css" />
     <link rel="stylesheet" href="../assets/styles/tab.css" />
     <link rel="stylesheet" href="../assets/styles/thumbnail.css" />
-    <script src="./"></script>
     <title>영화 리뷰</title>
   </head>
   <body>

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -9,8 +9,9 @@ module.exports = {
     path: path.resolve("dist/client"),
     filename: "bundle.js",
     clean: true,
-    publicPath: "/",
+    publicPath: "/client", // 페이지 요청과 bundle.js 요청을 구분하기 위함
   },
+  devtool: "source-map",
   module: {
     rules: [
       {

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -33,6 +33,11 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: "./views/index.html",
+      // 빌드 과정에서 template의 placeholder가 주석으로 인식되어 사라지는 문제 방지를 위함
+      minify: {
+        collapseWhitespace: true,
+        removeComments: false,
+      },
     }),
     new CopyPlugin({
       patterns: [


### PR DESCRIPTION
반갑습니다 지니 😄
SSR 1단계 미션 리뷰 잘 부탁드립니다!!

## 👀 리뷰를 통한 생각 나눔

### 1. SSR 렌더링 시 초기 렌더링 성능이 왜 유리할까?

1. SSR이 CSR에 비해 네트워크 수가 적습니다. CSR은 빈 html을 불러오고 난 후, 화면을 그리기 위해 별도의 js 파일을 또 불러와야 합니다. SSR은 html을 만드는 단계에서 이미 작업이 다 끝나기 때문에, 브라우저에서 별도의 js 파일을 불러올 필요 없이 이미 완성된 html을 불러오고 렌더링하면 끝납니다.
2. SSR이 CSR에 비해 브라우저가 렌더링 작업을 덜 합니다. CSR의 경우 빈 html을 렌더링하고, js 파일을 불러온 후 또 렌더링하고, 데이터 페칭 후 또 렌더링합니다. SSR은 이미 완성된 html을 불러오기 때문에 한 번만 렌더링하면 됩니다.
3. CSR보다 리소스 크기가 작습니다. CSR은 렌더링을 위한 js 파일을 브라우저가 실행해야 합니다. 이 js 파일에는 React가 동작하기 위한 모든 코드가 포함되어 있기 때문에 크기가 큽니다. SSR의 경우, 각 요청의 응답에 필요한 js 코드만 서버에서 실행하면 됩니다.

- CSR 플로우: html 요청 및 응답 → 렌더링 → js 요청 및 응답 → js 실행 → 리렌더링 → (클라이언트가) 데이터 페칭 → 리렌더링
    
    ![image](https://github.com/user-attachments/assets/612f9b36-df76-4b45-9fcc-dfc0ac53b319)


    
- SSR 플로우: html 요청 → (서버가) 데이터 페칭 → html에 데이터 삽입 → 응답→ 렌더링
    
    ![image](https://github.com/user-attachments/assets/be635fed-dca3-47d0-8835-f87006ae1067)

    

### 2. 서버에서 렌더링한 영화 목록을 어떻게 클라이언트에 데이터를 전달하고 브라우저에서는 어떤 작업을 수행할까?

1. 서버 사이드 렌더링 과정에서 script 태그를 만들어 반환할 html 내부에 넣어줍니다. 이 script는 전역 변수에 영화 목록을 할당합니다.
2. 브라우저가 html 파일을 모두 파싱하여 렌더링할 때 , script 태그를 만나면 실행합니다. 이 script의 실행 이후 영화 목록은 전역 변수에 할당되어 클라이언트 어디에서든 접근할 수 있습니다.

### 3. 전역 객체 초기화 작업은 왜 진행해야 할까?

1. 동일한 데이터 요청 작업을 서버와 클라이언트가 중복해서 할 필요가 없기 때문입니다.
2. hydration 과정에서 서버와 클라이언트의 렌더링 결과물을 동일하게 하기 위해서입니다. 서버와 클라이언트 렌더링 결과물이 다르면 사용자를 혼란스럽게 하고, 버그가 발생할 수 있습니다.

    
![image](https://github.com/user-attachments/assets/fe439928-42d6-4184-aff6-b40ea77d04ce)
> https://ko.react.dev/reference/react-dom/client/hydrateRoot#hydrateroot
