### PR TITLE
[서버 사이드 렌더링 - 2단계] 러기(박정우) 미션 제출합니다.

### DIFF
--- a/src/client/components/HeaderContent.jsx
+++ b/src/client/components/HeaderContent.jsx
@@ -19,7 +19,7 @@ export default function HeaderContent({ movie }) {
             <span className="rate-value">{round(vote_average, 1)}</span>
           </div>
           <div className="title">{title}</div>
-          <div onClick={() => console.log("hydrate")}>
+          <div onClick={() => window.history.pushState({}, "", `/detail/${id}`)}>
             <button className="primary detail">자세히 보기</button>
           </div>
         </div>

--- a/src/client/components/Modal.jsx
+++ b/src/client/components/Modal.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from "react";
+import useCustomRouting from "../hooks/useCustomRouting";
+import { round } from "../utils";
+import { TMDB_ORIGINAL_URL } from "../../constants";
+
+function Modal() {
+  const { currentPath, match } = useCustomRouting();
+  const id = match.params[0];
+  const INIT_DATA = window.__INITIAL_DATA__;
+  const [movie, setMovie] = useState(INIT_DATA.movies.find((movie) => movie.id === Number(id)));
+
+  useEffect(() => {
+    if (id) {
+      async function getMovie() {
+        const res = await fetch(`/api/getMovie/${id}`);
+        const { movie } = await res.json();
+        setMovie(movie);
+      }
+      getMovie();
+    }
+  }, [currentPath]);
+
+  if (match.name !== "detail" && !id) return null;
+
+  return (
+    <div className="modal-background active" id="modalBackground">
+      <div className="modal">
+        <button className="close-modal" id="closeModal" onClick={() => window.history.pushState({}, "", `/`)}>
+          <img src={"/assets/images/modal_button_close.png"} />
+        </button>
+        <div className="modal-container">
+          <div className="modal-image">{movie && <img src={TMDB_ORIGINAL_URL + movie?.poster_path} />}</div>
+          <div className="modal-description">
+            <h2>{movie?.title}</h2>
+            <p className="category">
+              {movie?.release_date.split("-")[0]} · {movie?.genres?.map(({ name }) => name).join(" ")}
+            </p>
+            <p className="rate">
+              <img src={"/assets/images/star_empty.png"} className="star" />
+              <span>{round(movie?.vote_average, 1)}</span>
+            </p>
+            <hr />
+            <p className="detail">{movie?.overview}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Modal;
+
+Modal.propTypes = {
+  //   onCloseButtonClick: PropTypes.func,
+};

--- a/src/client/components/Movies.jsx
+++ b/src/client/components/Movies.jsx
@@ -28,7 +28,7 @@ export default function Movies({ movies }) {
             rate={vote_average}
             title={title}
             thumbnailUrl={poster_path}
-            onClick={() => console.log("hydrate")}
+            onClick={() => window.history.pushState({}, "", `/detail/${id}`)}
           />
         </li>
       ))}

--- a/src/client/components/ServerModal.jsx
+++ b/src/client/components/ServerModal.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { round } from "../utils";
+import { TMDB_ORIGINAL_URL } from "../../constants";
+
+function ServerModal({ movie }) {
+  if (!movie) return null;
+  return (
+    <div className="modal-background active" id="modalBackground">
+      <div className="modal">
+        <button className="close-modal" id="closeModal" onClick={() => window.history.pushState({}, "", `/`)}>
+          <img src={"/assets/images/modal_button_close.png"} />
+        </button>
+        <div className="modal-container">
+          <div className="modal-image">{movie && <img src={TMDB_ORIGINAL_URL + movie?.poster_path} />}</div>
+          <div className="modal-description">
+            <h2>{movie?.title}</h2>
+            <p className="category">
+              {movie?.release_date.split("-")[0]} · {movie?.genres?.map(({ name }) => name).join(" ")}
+            </p>
+            <p className="rate">
+              <img src={"/assets/images/star_empty.png"} className="star" />
+              <span>{round(movie?.vote_average, 1)}</span>
+            </p>
+            <hr />
+            <p className="detail">{movie?.overview}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ServerModal;

--- a/src/client/hooks/useCustomRouting.js
+++ b/src/client/hooks/useCustomRouting.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { matchRoute } from "../utils";
+import URLObserver from "../observer/URLObserver";
+
+const urlObserver = new URLObserver();
+
+export default function useCustomRouting() {
+  const [currentPath, setCurrentPath] = useState(window.location.pathname);
+
+  useEffect(() => {
+    const listener = (newPath) => {
+      setCurrentPath(newPath);
+    };
+
+    urlObserver.addListener(listener);
+
+    return () => {
+      urlObserver.removeListener(listener);
+    };
+  }, []);
+
+  return { currentPath, match: matchRoute(currentPath) };
+}

--- a/src/client/hooks/useCustomRouting.js
+++ b/src/client/hooks/useCustomRouting.js
@@ -1,23 +1,19 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { matchRoute } from "../utils";
 import URLObserver from "../observer/URLObserver";
 
 const urlObserver = new URLObserver();
 
 export default function useCustomRouting() {
-  const [currentPath, setCurrentPath] = useState(window.location.pathname);
-
-  useEffect(() => {
-    const listener = (newPath) => {
-      setCurrentPath(newPath);
-    };
-
-    urlObserver.addListener(listener);
-
-    return () => {
-      urlObserver.removeListener(listener);
-    };
-  }, []);
+  const currentPath = useSyncExternalStore(
+    (callback) => {
+      urlObserver.addListener(callback);
+      return () => {
+        urlObserver.removeListener(callback);
+      };
+    },
+    () => window.location.pathname
+  );
 
   return { currentPath, match: matchRoute(currentPath) };
 }

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -3,10 +3,22 @@ import { createRoot, hydrateRoot } from "react-dom/client";
 import Movies from "./components/movies";
 import HeaderContent from "./components/HeaderContent";
 import Modal from "./components/Modal";
+import ServerModal from "./components/ServerModal";
+import URLObserver from "./observer/URLObserver";
 
 const INIT_DATA = window.__INITIAL_DATA__;
 
 hydrateRoot(document.getElementById("HEADER"), <HeaderContent movie={INIT_DATA.movies[0]} />);
 hydrateRoot(document.getElementById("MOVIE_ITEMS"), <Movies movies={INIT_DATA.movies} />);
 
-createRoot(document.getElementById("MODAL_AREA")).render(<Modal />);
+const isDetailPath = (path) => /^\/detail\/[^\/]+$/.test(path);
+
+const currentPath = window.location.pathname;
+
+if (isDetailPath(currentPath)) {
+  const root = hydrateRoot(document.getElementById("MODAL_AREA"), <ServerModal movie={INIT_DATA.movie} />);
+  const urlObserver = new URLObserver();
+  urlObserver.addListener(() => root.render(<Modal />));
+} else {
+  createRoot(document.getElementById("MODAL_AREA")).render(<Modal />);
+}

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,9 +1,12 @@
 import React from "react";
-import { hydrateRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import Movies from "./components/movies";
 import HeaderContent from "./components/HeaderContent";
+import Modal from "./components/Modal";
 
 const INIT_DATA = window.__INITIAL_DATA__;
 
 hydrateRoot(document.getElementById("HEADER"), <HeaderContent movie={INIT_DATA.movies[0]} />);
 hydrateRoot(document.getElementById("MOVIE_ITEMS"), <Movies movies={INIT_DATA.movies} />);
+
+createRoot(document.getElementById("MODAL_AREA")).render(<Modal />);

--- a/src/client/observer/URLObserver.js
+++ b/src/client/observer/URLObserver.js
@@ -1,0 +1,37 @@
+class URLObserver {
+  constructor() {
+    this.path = window.location.pathname;
+    this.listeners = new Set();
+
+    //pushState 오버라이드
+    const originalPushState = window.history.pushState;
+    window.history.pushState = (...args) => {
+      originalPushState.apply(window.history, args);
+      this.update();
+    };
+    //뒤로가기 앞으로가기 이벤트 발생시에도 감지
+    window.addEventListener("popstate", () => this.update());
+  }
+
+  update() {
+    const newPath = window.location.pathname;
+    if (this.path !== newPath) {
+      this.path = newPath;
+      this.notifyListeners();
+    }
+  }
+
+  notifyListeners() {
+    this.listeners.forEach((listener) => listener(this.path));
+  }
+
+  addListener(listener) {
+    this.listeners.add(listener);
+  }
+
+  removeListener(listener) {
+    this.listeners.delete(listener);
+  }
+}
+
+export default URLObserver;

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -2,3 +2,23 @@ export const round = (value, decimals = 0) => {
   const factor = 10 ** decimals;
   return Math.round(value * factor) / factor;
 };
+
+export function matchRoute(path) {
+  const routes = [
+    { pattern: /^\/detail\/(\d+)$/, name: "detail" },
+    { pattern: /^\/$/, name: "home" },
+  ];
+
+  const matchedRoute = routes.find((route) => path.match(route.pattern));
+
+  if (matchedRoute) {
+    const params = path.match(matchedRoute.pattern).slice(1);
+    return { name: matchedRoute.name, params };
+  }
+
+  return { name: "notFound", params: [] };
+}
+
+export const navigate = (path) => {
+  window.history.pushState({}, "", path);
+};

--- a/views/index.html
+++ b/views/index.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="../assets/styles/modal.css" />
     <link rel="stylesheet" href="../assets/styles/tab.css" />
     <link rel="stylesheet" href="../assets/styles/thumbnail.css" />
-    <script src="./"></script>
     <title>영화 리뷰</title>
   </head>
   <body>
@@ -28,7 +27,8 @@
         <p><img src="../assets/images/woowacourse_logo.png" width="180" /></p>
       </footer>
     </div>
-    <!--${MODAL_AREA}-->
+
+    <div id="MODAL_AREA"></div>
 
     <!--${INIT_DATA_AREA}-->
   </body>


### PR DESCRIPTION
쑤쑤 두번째 미션도 잘 부탁드려용~~~~~~~~~~~🚀

react-router를 사용할까 했는데~ History API사용하면 많이 배우겠다 싶어서 한 번 써봤습니다~
[History API MDN 바로가기➡️](https://developer.mozilla.org/ko/docs/Web/API/History)

## 👀 리뷰를 통한 생각 나눔

### SSR 환경에서 웹 브라우저는 어떤 과정으로 하이드레이션(hydration)을 진행하는지 상세히 서술하시오.
리액트는 최적화된 렌더링을 위해 가상돔과 자체적인 이벤트 시스템을 가지고 있습니다. 
Hydrate과정에서 정적인 HTML페이지에 이벤트를 전달하는 과정이라 할 수 있습니다.
하지만 이 과정에서도 새롭게 리액트 컴포넌트를 생성하는데(렌더링X), 이 과정에서 기존 Server에서 제공된 컴포넌트와 다른 구조를 가지면 이전 Step1에서 발생한 Hydrate Error가 발생하게 됩니다.
다른 구조를 가지게 되면, 기존 Server에서 제공된 컴포넌트는 Client에서 새롭게 생성된 컴포넌트로 리렌더링 되는데, 이 과정에서 깜박임, 예상과 다른 UI구조 생성 등 여러 측면에서 좋지못한 사용성을 제공할 가능성이 크기 때문에 에러를 발생하게 됩니다.

### 다음 두 가지 상황의 동작 과정을 비교해 설명하시오.
- 사용자가 처음 영화 목록 페이지에 접속할 때
- 하이드레이션 후, 사용자가 영화 목록에서 특정 영화를 클릭하여 상세 페이지로 이동할 때

이번 미션에서는 사용자가 처음 영화 목록 페이지에 접속할 때에 서버에서 HTML파일을 받게 됩니다. 하지만 하이드레이션 후, 사용자가 영화 목록에서 특정 영화를 클릭하여 상세 페이지로 이동할 때에는 History API를 이용하여 동적으로 라우트를 이동하게 되면서 서버에 HTML을 새롭게 요청하지 않게 됩니다.

### 다음 두 가지 상황의 동작 과정에서 라우팅의 차이점이 무엇인지 서술하시오.
- 사용자가 https://주소/detail/12345와 같이 브라우저에 직접 입력한 뒤 페이지로 이동할 때
- 하이드레이션 후, 사용자가 영화 목록에서 특정 영화를 클릭하여 상세 페이지로 이동할 때

사용자가 https://주소/detail/12345와 같이 브라우저에 직접 입력한 뒤 페이지로 이동할 때에는 express 서버의 /detail/12345라우트로 요청을 보내게 됩니다. 하지만 하이드레이션 후, 사용자가 영화 목록에서 특정 영화를 클릭하여 상세 페이지로 이동할 때에는 다른 요청을 보내지 않고, /경로의 HTML파일을 이용하게 됩니다.
