### PR TITLE
[서버 사이드 렌더링 - 2단계] 지니(손진영) 미션 제출합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "express": "^4.21.0",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.27.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.25.4",
@@ -2018,6 +2019,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz",
+      "integrity": "sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@sindresorhus/merge-streams": {
@@ -4695,6 +4704,36 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.27.0.tgz",
+      "integrity": "sha512-YA+HGZXz4jaAkVoYBE98VQl+nVzI+cVI2Oj/06F5ZM+0u3TgedN9Y9kmMRo2mnkSK2nCpNQn0DVob4HCsY/WLw==",
+      "dependencies": {
+        "@remix-run/router": "1.20.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
+      "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "dependencies": {
+        "@remix-run/router": "1.20.0",
+        "react-router": "6.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "express": "^4.21.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.27.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.25.4",

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -101,6 +101,7 @@ h1.logo {
   display: flex;
   align-items: baseline;
   color: var(--color-yellow);
+  gap: 4px;
 }
 
 .rate > img {

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 
-import MainPage from './pages/MainPage';
-import AppLayout from './components/AppLayout';
 import { ROUTE_PATHS } from '../constants/routePath';
 
-export default function App({ movies }) {
+import AppLayout from './components/AppLayout';
+
+import MainPage from './pages/MainPage';
+import MovieDetailPage from './pages/MovieDetailPage';
+
+export default function App({ initialMovieDetail, movies }) {
   return (
     <Routes>
-      <Route path={ROUTE_PATHS.root} element={<AppLayout movies={movies} />}>
-        <Route index element={<MainPage movies={movies} />} />
+      <Route element={<AppLayout movies={movies} />}>
+        <Route path={ROUTE_PATHS.root} element={<MainPage movies={movies} />} />
+        <Route
+          path={ROUTE_PATHS.movieDetail}
+          element={<MovieDetailPage initialMovieDetail={initialMovieDetail} movies={movies} />}
+        />
       </Route>
     </Routes>
   );

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,33 +1,16 @@
 import React from 'react';
-import MovieListItem from './components/MovieListItem.jsx';
-import Header from './components/Header.jsx';
+import { Routes, Route } from 'react-router-dom';
 
-import woowacourseLogo from '@images/woowacourse_logo.png';
+import MainPage from './pages/MainPage';
+import AppLayout from './components/AppLayout';
+import { ROUTE_PATHS } from '../constants/routePath';
 
-function App({ movies }) {
+export default function App({ movies }) {
   return (
-    <>
-      <Header movie={movies[0]} />
-      <div className="container">
-        <main>
-          <section>
-            <h2>지금 인기 있는 영화</h2>
-            <ul className="thumbnail-list">
-              {movies.map((movie) => (
-                <MovieListItem key={movie.id} movie={movie} />
-              ))}
-            </ul>
-          </section>
-        </main>
-      </div>
-      <footer class="footer">
-        <p>&copy; 우아한테크코스 All Rights Reserved.</p>
-        <p>
-          <img src={woowacourseLogo} width="180" />
-        </p>
-      </footer>
-    </>
+    <Routes>
+      <Route path={ROUTE_PATHS.root} element={<AppLayout movies={movies} />}>
+        <Route index element={<MainPage movies={movies} />} />
+      </Route>
+    </Routes>
   );
 }
-
-export default App;

--- a/src/client/components/AppLayout.jsx
+++ b/src/client/components/AppLayout.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import woowacourseLogo from '@images/woowacourse_logo.png';
+
+import Header from './Header';
+
+export default function AppLayout({ movies }) {
+  return (
+    <>
+      <Header movie={movies[0]} />
+      <div className="container">
+        <Outlet />
+      </div>
+      <footer class="footer">
+        <p>&copy; 우아한테크코스 All Rights Reserved.</p>
+        <p>
+          <img src={woowacourseLogo} width="180" />
+        </p>
+      </footer>
+    </>
+  );
+}

--- a/src/client/components/AppLayout.jsx
+++ b/src/client/components/AppLayout.jsx
@@ -11,10 +11,10 @@ export default function AppLayout({ movies }) {
       <div className="container">
         <Outlet />
       </div>
-      <footer class="footer">
+      <footer className="footer">
         <p>&copy; 우아한테크코스 All Rights Reserved.</p>
         <p>
-          <img src={woowacourseLogo} width="180" />
+          <img src={woowacourseLogo} width="180" alt="" />
         </p>
       </footer>
     </>

--- a/src/client/components/Header.jsx
+++ b/src/client/components/Header.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 
 import logo from '@images/logo.png';
 import starEmptyImage from '@images/star_empty.png';
+import { useNavigate } from 'react-router-dom';
 
 export default function Header({ movie }) {
+  const navigate = useNavigate();
   return (
     <header>
       <div
@@ -21,7 +23,9 @@ export default function Header({ movie }) {
               <span className="rate-value">{movie.rate}</span>
             </div>
             <div className="title">{movie.title}</div>
-            <button className="primary detail">자세히 보기</button>
+            <button className="primary detail" onClick={() => navigate(`detail/${movie.id}`)}>
+              자세히 보기
+            </button>
           </div>
         </div>
       </div>

--- a/src/client/components/MovieDetailModal.jsx
+++ b/src/client/components/MovieDetailModal.jsx
@@ -7,10 +7,6 @@ export default function MovieDetailModal({
   onCloseModal,
   isLoading,
 }) {
-  if (isLoading) {
-    return null;
-  }
-
   return (
     <div className="modal-background active" id="modalBackground">
       <div className="modal">
@@ -18,21 +14,25 @@ export default function MovieDetailModal({
           <img src={closeButton} alt="" />
         </button>
         <div className="modal-container">
-          <div className="modal-image">
-            <img src={thumbnailUrl} alt="" />
-          </div>
-          <div className="modal-description">
-            <h2>{title}</h2>
-            <p className="category">
-              {releaseYear} · {genres}
-            </p>
-            <p className="rate">
-              <img src={starEmptyImage} alt="" className="star" />
-              <span>{rate}</span>
-            </p>
-            <hr />
-            <p className="detail">{description}</p>
-          </div>
+          {!isLoading && (
+            <>
+              <div className="modal-image">
+                <img src={thumbnailUrl} alt="" />
+              </div>
+              <div className="modal-description">
+                <h2>{title}</h2>
+                <p className="category">
+                  {releaseYear} · {genres}
+                </p>
+                <p className="rate">
+                  <img src={starEmptyImage} alt="" className="star" />
+                  <span>{rate}</span>
+                </p>
+                <hr />
+                <p className="detail">{description}</p>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/client/components/MovieDetailModal.jsx
+++ b/src/client/components/MovieDetailModal.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import starEmptyImage from '@images/star_empty.png';
+import closeButton from '@images/modal_button_close.png';
+
+export default function MovieDetailModal({
+  movieDetail: { title, rate, thumbnailUrl, description, releaseYear, genres },
+  onCloseModal,
+  isLoading,
+}) {
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <div className="modal-background active" id="modalBackground">
+      <div className="modal">
+        <button className="close-modal" id="closeModal" onClick={onCloseModal}>
+          <img src={closeButton} alt="" />
+        </button>
+        <div className="modal-container">
+          <div className="modal-image">
+            <img src={thumbnailUrl} alt="" />
+          </div>
+          <div className="modal-description">
+            <h2>{title}</h2>
+            <p className="category">
+              {releaseYear} · {genres}
+            </p>
+            <p className="rate">
+              <img src={starEmptyImage} alt="" className="star" />
+              <span>{rate}</span>
+            </p>
+            <hr />
+            <p className="detail">{description}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/MovieListItem.jsx
+++ b/src/client/components/MovieListItem.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import starEmptyImage from '@images/star_empty.png';
+import { useNavigate } from 'react-router-dom';
 
 function MovieListItem({ movie }) {
+  const navigate = useNavigate();
   return (
-    <li onClick={() => alert(`You clicked on ${movie.title}`)} className="item">
+    <li onClick={() => navigate(`/detail/${movie.id}`)} className="item">
       <img className="thumbnail" src={movie.thumbnailUrl} alt={movie.title} />
       <div className="item-desc">
         <div className="rate">

--- a/src/client/hooks/useMovieDetail.js
+++ b/src/client/hooks/useMovieDetail.js
@@ -6,7 +6,7 @@ function useMovieDetail(initialMovieDetail, id) {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const isServerSideRendering = String(initialMovieDetail.id) === id;
+    const isServerSideRendering = String(initialMovieDetail?.id) === id;
 
     if (isServerSideRendering) return;
 

--- a/src/client/hooks/useMovieDetail.js
+++ b/src/client/hooks/useMovieDetail.js
@@ -2,10 +2,14 @@ import { useEffect, useState } from 'react';
 import { fetchMovieDetail } from '../../server/apis/movies';
 
 function useMovieDetail(initialMovieDetail, id) {
-  const [movieDetail, setMovieDetail] = useState(null);
+  const [movieDetail, setMovieDetail] = useState(initialMovieDetail);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    const isServerSideRendering = String(initialMovieDetail.id) === id;
+
+    if (isServerSideRendering) return;
+
     let isMounted = true;
     setIsLoading(true);
 
@@ -14,22 +18,17 @@ function useMovieDetail(initialMovieDetail, id) {
         const data = await fetchMovieDetail(id);
         if (isMounted) {
           setMovieDetail(data);
-          setIsLoading(false);
         }
       } catch (error) {
         console.error('영화 상세 목록을 보여주는데 실패했습니다 :(', error);
+      } finally {
         if (isMounted) {
           setIsLoading(false);
         }
       }
     };
 
-    if (id) {
-      fetchData();
-    } else {
-      setMovieDetail(initialMovieDetail);
-      setIsLoading(false);
-    }
+    fetchData();
 
     return () => {
       isMounted = false;

--- a/src/client/hooks/useMovieDetail.js
+++ b/src/client/hooks/useMovieDetail.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { fetchMovieDetail } from '../../server/apis/movies';
+
+function useMovieDetail(initialMovieDetail, id) {
+  const [movieDetail, setMovieDetail] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    setIsLoading(true);
+
+    const fetchData = async () => {
+      try {
+        const data = await fetchMovieDetail(id);
+        if (isMounted) {
+          setMovieDetail(data);
+          setIsLoading(false);
+        }
+      } catch (error) {
+        console.error('영화 상세 목록을 보여주는데 실패했습니다 :(', error);
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    if (id) {
+      fetchData();
+    } else {
+      setMovieDetail(initialMovieDetail);
+      setIsLoading(false);
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [id, initialMovieDetail]);
+
+  return { movieDetail, isLoading };
+}
+
+export default useMovieDetail;

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,5 +1,11 @@
 import React from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import App from './App';
+import { BrowserRouter } from 'react-router-dom';
 
-hydrateRoot(document.getElementById('root'), <App movies={window.__INITIAL_DATA__.movies} />);
+hydrateRoot(
+  document.getElementById('root'),
+  <BrowserRouter>
+    <App movies={window.__INITIAL_DATA__.movies} />
+  </BrowserRouter>
+);

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -6,6 +6,9 @@ import { BrowserRouter } from 'react-router-dom';
 hydrateRoot(
   document.getElementById('root'),
   <BrowserRouter>
-    <App movies={window.__INITIAL_DATA__.movies} />
+    <App
+      initialMovieDetail={window.__INITIAL_DATA__.movie}
+      movies={window.__INITIAL_DATA__.movies}
+    />
   </BrowserRouter>
 );

--- a/src/client/pages/MainPage.jsx
+++ b/src/client/pages/MainPage.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import MovieListItem from '../components/MovieListItem.jsx';
+
+function MainPage({ movies }) {
+  return (
+    <main>
+      <section>
+        <h2>지금 인기 있는 영화</h2>
+        <ul className="thumbnail-list">
+          {movies.map((movie) => (
+            <MovieListItem key={movie.id} movie={movie} />
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}
+
+export default MainPage;

--- a/src/client/pages/MovieDetailPage.jsx
+++ b/src/client/pages/MovieDetailPage.jsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import MainPage from './MainPage';
+import MovieDetailModal from '../components/MovieDetailModal';
+import useMovieDetail from '../hooks/useMovieDetail';
+
+export default function MovieDetailPage({ initialMovieDetail, movies }) {
+  const [isOpen, setIsOpen] = useState(true);
+  const { id } = useParams();
+
+  const { movieDetail, isLoading } = useMovieDetail(initialMovieDetail, id);
+
+  const handleCloseModal = () => setIsOpen(false);
+
+  const isMovieDetail = (movieDetail || initialMovieDetail) !== undefined;
+
+  useEffect(() => {
+    setIsOpen(true);
+  }, [id]);
+
+  return (
+    <>
+      <MainPage movies={movies} />
+      {isMovieDetail && isOpen && (
+        <MovieDetailModal
+          isLoading={isLoading}
+          movieDetail={movieDetail || initialMovieDetail}
+          onCloseModal={handleCloseModal}
+        />
+      )}
+    </>
+  );
+}

--- a/src/client/pages/MovieDetailPage.jsx
+++ b/src/client/pages/MovieDetailPage.jsx
@@ -1,22 +1,24 @@
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import MainPage from './MainPage';
 import MovieDetailModal from '../components/MovieDetailModal';
 import useMovieDetail from '../hooks/useMovieDetail';
+import { ROUTE_PATHS } from '../../constants/routePath';
 
 export default function MovieDetailPage({ initialMovieDetail, movies }) {
   const [isOpen, setIsOpen] = useState(true);
   const { id } = useParams();
 
+  const navigate = useNavigate();
+
   const { movieDetail, isLoading } = useMovieDetail(initialMovieDetail, id);
 
-  const handleCloseModal = () => setIsOpen(false);
+  const handleCloseModal = () => {
+    setIsOpen(false);
+    navigate(ROUTE_PATHS.root);
+  };
 
   const isMovieDetail = (movieDetail || initialMovieDetail) !== undefined;
-
-  useEffect(() => {
-    setIsOpen(true);
-  }, [id]);
 
   return (
     <>

--- a/src/constants/routePath.js
+++ b/src/constants/routePath.js
@@ -1,0 +1,3 @@
+export const ROUTE_PATHS = {
+  root: '/',
+};

--- a/src/constants/routePath.js
+++ b/src/constants/routePath.js
@@ -1,3 +1,4 @@
 export const ROUTE_PATHS = {
   root: '/',
+  movieDetail: '/detail/:id',
 };

--- a/src/server/apis/movies.js
+++ b/src/server/apis/movies.js
@@ -1,24 +1,53 @@
-import { TMDB_BANNER_URL, TMDB_MOVIE_LISTS, TMDB_THUMBNAIL_URL } from './url.js';
+import {
+  TMDB_BANNER_URL,
+  TMDB_MOVIE_DETAIL_URL,
+  TMDB_MOVIE_LISTS,
+  TMDB_THUMBNAIL_URL,
+} from './url.js';
 
-const fetchMovieList = async (type) => {
-  const response = await fetch(TMDB_MOVIE_LISTS[type || 'nowPlaying'], {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${process.env.TMDB_TOKEN}`,
-    },
-  });
+import { addQueryParams } from '../utils/query.js';
+
+const FETCH_OPTIONS = {
+  method: 'GET',
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.TMDB_TOKEN}`,
+  },
+};
+
+const movieFetcher = async (url) => {
+  const urlWithQuery = addQueryParams(url, { language: 'ko-KR' });
+  const response = await fetch(urlWithQuery, FETCH_OPTIONS);
 
   return await response.json();
 };
 
 export async function fetchNowPlayingMovies() {
-  const data = await fetchMovieList('nowPlaying');
+  const data = await movieFetcher(TMDB_MOVIE_LISTS['nowPlaying']);
 
-  return data.results.map(({ title, vote_average, backdrop_path, poster_path }) => ({
+  return data.results.map(({ id, title, vote_average, backdrop_path, poster_path }) => ({
+    id,
     title,
     rate: vote_average.toFixed(1),
     backdropUrl: `${TMDB_BANNER_URL}/${backdrop_path}`,
     thumbnailUrl: `${TMDB_THUMBNAIL_URL}${poster_path}`,
   }));
+}
+
+export async function fetchMovieDetail(movieId) {
+  const movieDetailUrl = `${TMDB_MOVIE_DETAIL_URL}${movieId}`;
+
+  const { title, vote_average, backdrop_path, poster_path, genres, release_date, overview } =
+    await movieFetcher(movieDetailUrl);
+
+  const releaseYear = release_date.slice(0, 4);
+
+  return {
+    title,
+    releaseYear,
+    rate: vote_average.toFixed(1),
+    thumbnailUrl: `${TMDB_THUMBNAIL_URL}${poster_path}`,
+    genres: genres.map((genre) => genre.name).join(', '),
+    description: overview,
+  };
 }

--- a/src/server/apis/movies.js
+++ b/src/server/apis/movies.js
@@ -37,12 +37,13 @@ export async function fetchNowPlayingMovies() {
 export async function fetchMovieDetail(movieId) {
   const movieDetailUrl = `${TMDB_MOVIE_DETAIL_URL}${movieId}`;
 
-  const { title, vote_average, backdrop_path, poster_path, genres, release_date, overview } =
+  const { id, title, vote_average, poster_path, genres, release_date, overview } =
     await movieFetcher(movieDetailUrl);
 
   const releaseYear = release_date.slice(0, 4);
 
   return {
+    id,
     title,
     releaseYear,
     rate: vote_average.toFixed(1),

--- a/src/server/apis/url.js
+++ b/src/server/apis/url.js
@@ -3,9 +3,7 @@ export const BASE_URL = 'https://api.themoviedb.org/3/movie';
 export const TMDB_THUMBNAIL_URL = 'https://media.themoviedb.org/t/p/w440_and_h660_face/';
 export const TMDB_ORIGINAL_URL = 'https://image.tmdb.org/t/p/original/';
 export const TMDB_BANNER_URL = 'https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/';
+export const TMDB_MOVIE_DETAIL_URL = 'https://api.themoviedb.org/3/movie/';
 export const TMDB_MOVIE_LISTS = {
-  popular: BASE_URL + '/popular?language=ko-KR&page=1',
   nowPlaying: BASE_URL + '/now_playing?language=ko-KR&page=1',
-  topRated: BASE_URL + '/top_rated?language=ko-KR&page=1',
-  upcoming: BASE_URL + '/upcoming?language=ko-KR&page=1',
 };

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,10 +1,10 @@
 import { Router } from 'express';
-import { renderHTML } from '../utils/render.js';
+import { renderRootHTML } from '../utils/render.js';
 
 const router = Router();
 
 router.get('/', async (_, res) => {
-  const html = await renderHTML();
+  const html = await renderRootHTML();
 
   res.send(html);
 });

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,10 +1,18 @@
 import { Router } from 'express';
-import { renderRootHTML } from '../utils/render.js';
+import { renderMovieDetailHTML, renderRootHTML } from '../utils/render.js';
 
 const router = Router();
 
 router.get('/', async (_, res) => {
   const html = await renderRootHTML();
+
+  res.send(html);
+});
+
+router.get('/detail/:id', async (req, res) => {
+  const movieId = req.params.id;
+
+  const html = await renderMovieDetailHTML(movieId);
 
   res.send(html);
 });

--- a/src/server/utils/query.js
+++ b/src/server/utils/query.js
@@ -1,0 +1,5 @@
+export function addQueryParams(url, params) {
+  const urlObject = new URL(url);
+  Object.keys(params).forEach((key) => urlObject.searchParams.append(key, params[key]));
+  return urlObject.toString();
+}

--- a/src/server/utils/render.js
+++ b/src/server/utils/render.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 
-import { fetchNowPlayingMovies } from '../apis/movies.js';
+import { fetchMovieDetail, fetchNowPlayingMovies } from '../apis/movies.js';
 
 import App from '../../client/App.jsx';
 
@@ -23,7 +23,7 @@ export async function renderRootHTML() {
 
   const renderedApp = renderToString(
     <StaticRouter location={'/'}>
-      <App movies={nowPlayingMovies} />
+      <App initialMovieDetail={null} movies={nowPlayingMovies} />
     </StaticRouter>
   );
 
@@ -33,6 +33,31 @@ export async function renderRootHTML() {
       <script>
         window.__INITIAL_DATA__ = {
           movies: ${JSON.stringify(nowPlayingMovies)}
+        }
+      </script>
+    `
+  );
+}
+
+export async function renderMovieDetailHTML(movieId) {
+  const template = createHTMLTemplate();
+
+  const nowPlayingMovies = await fetchNowPlayingMovies();
+  const movieDetail = await fetchMovieDetail(movieId);
+
+  const renderedApp = renderToString(
+    <StaticRouter location={`/detail/${movieId}`}>
+      <App initialMovieDetail={movieDetail} movies={nowPlayingMovies} />
+    </StaticRouter>
+  );
+
+  return template.replace('<div id="root"></div>', `<div id="root">${renderedApp}</div>`).replace(
+    '<!--${INIT_DATA_AREA}-->',
+    `
+      <script>
+        window.__INITIAL_DATA__ = {
+          movies: ${JSON.stringify(nowPlayingMovies)},
+          movie : ${JSON.stringify(movieDetail)},
         }
       </script>
     `

--- a/src/server/utils/render.js
+++ b/src/server/utils/render.js
@@ -3,10 +3,11 @@ import path from 'path';
 
 import React from 'react';
 import { renderToString } from 'react-dom/server';
+import { StaticRouter } from 'react-router-dom/server';
 
 import { fetchNowPlayingMovies } from '../apis/movies.js';
 
-import App from '../../client/App';
+import App from '../../client/App.jsx';
 
 export function createHTMLTemplate() {
   const templatePath = path.resolve(__dirname, 'index.html');
@@ -15,12 +16,16 @@ export function createHTMLTemplate() {
   return template;
 }
 
-export async function renderHTML() {
+export async function renderRootHTML() {
   const template = createHTMLTemplate();
 
   const nowPlayingMovies = await fetchNowPlayingMovies();
 
-  const renderedApp = renderToString(<App movies={nowPlayingMovies} />);
+  const renderedApp = renderToString(
+    <StaticRouter location={'/'}>
+      <App movies={nowPlayingMovies} />
+    </StaticRouter>
+  );
 
   return template.replace('<div id="root"></div>', `<div id="root">${renderedApp}</div>`).replace(
     '<!--${INIT_DATA_AREA}-->',

--- a/views/index.html
+++ b/views/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>영화 리뷰</title>
-    <link rel="stylesheet" href="./static/styles/index.css" />
+    <link rel="stylesheet" href="/static/styles/index.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -1,9 +1,14 @@
 const path = require('path');
+const webpack = require('webpack');
+
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const dotenv = require('dotenv');
+
+const env = dotenv.config().parsed;
 
 module.exports = {
-  module: 'development',
+  mode: 'development',
   entry: './src/client/main.js',
   output: {
     path: path.resolve('dist'),
@@ -51,6 +56,9 @@ module.exports = {
         { from: 'public/images', to: 'images' },
         { from: 'public/styles', to: 'styles' },
       ],
+    }),
+    new webpack.DefinePlugin({
+      'process.env': JSON.stringify(env),
     }),
   ],
   resolve: {


### PR DESCRIPTION
안녕하세요 러기 :) 최종 데모데이 준비는 잘 되가시나요~?

요즘도 왔다감(왔)에 종종 보이시던데 꾸준하게 일찍 오시는게 멋집니다 👍👍👍

러기와 함께 마지막 미션을 진행할 수 있어서 좋네여 ㅎㅎ 프론트엔드 마지막 미션도 잘 부탁드려요~!

## 👀 리뷰를 통한 생각 나눔

### 1. SSR 환경에서 웹 브라우저는 어떤 과정으로 하이드레이션(hydration)을 진행하는지 상세히 서술하시오.

💡 작성 요령: 서버에서 렌더링된 HTML과 클라이언트 측에서 React로 다시 그려질 때 발생할 수 있는 차이점은 무엇이며, 이로 인해 생길 수 있는 문제는 어떤 것이 있는지 고민해 보세요.

서버 사이드 렌더링의 경우 서버 측에서 먼저 html을 반환하게 됩니다.

그 후 아래와 같은 과정으로 웹 브라우저는 하이드레이션을 진행합니다.

1. 브라우저 렌더링 과정에서 서버로부터 받은 HTML을 파싱
2. 번들 파일에 해당 되는 script 태그를 만날 경우 클라이언트의 번들 파일을 실행한다.
3. main.js 내 `hydrateRoot`가 실행되면서 서버에서 내려준 html 트리와 리액트의 가상 dom 트리를 서로 비교하여 일치하는지 확인한다.
4. 일치할 경우 필요한 이벤트 리스너를 dom 요소에 연결한다.

이 과정을 통해 영화 애플리케이션은 초기 렌더링 이후에도 사용자가 특정 인터렉션을 발생시켰을 때 필요한 동작을 수행하게 됩니다.

### 2. 다음 두 가지 상황의 동작 과정을 비교해 설명하시오.
> 사용자가 처음 영화 목록 페이지에 접속할 때

> 하이드레이션 후, 사용자가 영화 목록에서 특정 영화를 클릭하여 상세 페이지로 이동할 때

현재 구현된 앱의 경우 **렌더링하는 주체가 다르다**는 차이점이 있습니다.

1번 상황의 경우 렌더링하는 주체는 `서버` 입니다.

서버 사이드 렌더링 과정을 수행하여 초기 컨텐츠를 보여주고 하이드레이션 과정을 통해 유저 인터렉션을 가능하게 합니다.

2번 상황의 경우 렌더링하는 주체는 `클라이언트` 입니다.

특정 영화를 클릭할 경우 react-router-dom의 `navigate` 함수에 의해 영화 목록 상세 페이지(/detail/:id)로 이동합니다.

그 후, 클라이언트 내에서(MovieDetailPage) 해당 영화 정보를 데이터 패칭 후 렌더링하는 형태입니다.

이를 통해 ssr과 csr의 장점만을 취할 수 있다는 장점이 있습니다.
(ssr의 경우 초기 로딩 속도가 빠르다는 장점이, csr의 경우 전체 html에 대한 요청이 아닌 부분적인 요소만 렌더링 해서 보여줄 수 있는 장점)

### 3. 다음 두 가지 상황의 동작 과정에서 라우팅의 차이점이 무엇인지 서술하시오.

> 사용자가 https://주소/detail/12345와 같이 브라우저에 직접 입력한 뒤 페이지로 이동할 때

> 하이드레이션 후, 사용자가 영화 목록에서 특정 영화를 클릭하여 상세 페이지로 이동할 때

사실상 2번과 같은 답변인거 같아 생략 해보려고 합니다,,

차이점이 있다면 서버 사이드 렌더링 환경에선 react-router-dom의 `static router`를 클라이언트 사이드 렌더링 환경에선 `browser router`를 사용한다는 점입니다.

직접 url을 입력해서 접근할 경우 서버에서 static router를 통해 초기 라우팅을 결정하여 해당 컴포넌트를 렌더링합니다.

따라서, static router를 만약 없앤다면 아래와 같은 에러를 발생시킵니다.

```
/Users/sonjin-yeong/Desktop/react-ssr/node_modules/@remix-run/router/dist/router.cjs.js:315
    throw new Error(message);
          ^
Error: useRoutes() may be used only in the context of a <Router> component.
    at Object.invariant [as UNSAFE_invariant] (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/@remix-run/router/dist/router.cjs.js:315:11)
    at useRoutesImpl (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-router/dist/umd/react-router.development.js:348:36)
    at useRoutes (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-router/dist/umd/react-router.development.js:343:12)
    at Routes (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-router/dist/umd/react-router.development.js:1243:12)
    at renderWithHooks (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5662:16)
    at renderIndeterminateComponent (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5736:15)
    at renderElement (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5961:7)
    at renderNodeDestructiveImpl (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6119:11)
    at renderNodeDestructive (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:6091:14)
    at renderIndeterminateComponent (/Users/sonjin-yeong/Desktop/react-ssr/node_modules/react-dom/cjs/react-dom-server-legacy.node.development.js:5790:7)
Node.js v20.15.1
```

반면, 특정 컴포넌트를 클릭해 접근할 경우, 브라우저의 history api를 활용한 browser router를 활용하여 클라이언트 사이드 라우팅을 처리한다는 차이점이 있습니다.